### PR TITLE
updated sharp dependency to use the latest libvip library

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "get-rgba-palette": "^2.0.1",
     "loader-utils": "^2.0.0",
     "schema-utils": "^2.6.6",
-    "sharp": "0.26.3",
+    "sharp": "^0.29.2",
     "svgo": "^1.3.2",
     "url-loader": "^4.1.0"
   },


### PR DESCRIPTION
above version .29, sharp supports arm chip sets cause it uses the newest version of the libvip library.